### PR TITLE
Fix for Sponge Chunk item issues

### DIFF
--- a/src/main/java/com/sirsquidly/oe/common/CreativeTab.java
+++ b/src/main/java/com/sirsquidly/oe/common/CreativeTab.java
@@ -124,7 +124,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 	        }
 	        if (ConfigHandler.block.enableSeastar) add(list, OEBlocks.SEASTAR);
 	        if (ConfigHandler.block.tubeSponge.enableTubeSponge) add(list, OEBlocks.TUBE_SPONGE);
-	        add(list, OEItems.SPONGE_CHUNK);
+			if (ConfigHandler.item.spongeChunk.enableSpongeChunk) add(list, OEItems.SPONGE_CHUNK);
 	        
 	        if (ConfigHandler.block.coralBlocks.enableCoralBlock) 
 	        {

--- a/src/main/java/com/sirsquidly/oe/items/ItemSpongeChunk.java
+++ b/src/main/java/com/sirsquidly/oe/items/ItemSpongeChunk.java
@@ -82,7 +82,7 @@ public class ItemSpongeChunk extends Item
 		
 		if (!worldIn.provider.doesWaterVaporize() && ConfigHandler.item.spongeChunk.spongeChunkMaxSaturation != 0)
 		{
-			if (player.canPlayerEdit(pos, facing, itemstack))
+			if (!this.isFull(itemstack) && player.canPlayerEdit(pos, facing, itemstack))
 			{
 				doWaterCollection(worldIn, pos, player, hand, itemstack);
 			}


### PR DESCRIPTION
Hi, I found two issues with the Sponge Chunk item

On the current build at 94c9401, when you use a Wet Sponge Chunk item, it continues to drain. It's an infinite sponge!. The first commit in this PR fixes that by adding a `!this.isFull(itemstack)` check.

Secondly, also on the current build at 94c9401, if you disable Sponge Chunk in config, the creative tab still registers a null entry, and this null entry crashes the game on hover. The second commit in this PR fixes that by adding the relevant config check `if (ConfigHandler.item.spongeChunk.enableSpongeChunk) ...`

I figured since these cover the same item, better to have it as one PR instead of two.