### PR TITLE
fixed constant crashlogs with trident saving

### DIFF
--- a/src/main/java/com/sirsquidly/oe/entity/item/EntityTrident.java
+++ b/src/main/java/com/sirsquidly/oe/entity/item/EntityTrident.java
@@ -449,6 +449,9 @@ public class EntityTrident extends AbstractArrow
         {
             compound.setTag("Item", this.getItem().writeToNBT(new NBTTagCompound()));
         }
-		compound.setString("TrueOwner", this.trueOwner.getUniqueID().toString());
+		if(this.trueOwner instanceof EntityPlayer)
+		{
+			compound.setString("TrueOwner", this.trueOwner.getUniqueID().toString());
+		}
 	}
 }


### PR DESCRIPTION
in readfromnbt trueowner is assumed to be a player. if drowned throw tridents, those tridents will flood the logs with nbt saving crashlogs once youve unloaded them once, because after first reload their trueowner will be null.